### PR TITLE
Fix broken test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,11 @@ jobs:
 
       - name: install kubebuilder
         id: install-kubebuilder
-        uses: RyanSiu1995/kubebuilder-action@v1
-        with:
-          version: 2.3.1
+        run: os=$(go env GOOS)
+             arch=$(go env GOARCH)
+             curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+             sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+             export PATH=$PATH:/usr/local/kubebuilder/bin
 
       - id: test-code
         name: test


### PR DESCRIPTION
This change fixes `install kubebuilder` step to use kube-builder's official script.